### PR TITLE
themes: float window now can be transparent

### DIFF
--- a/lua/one_monokai/colors.lua
+++ b/lua/one_monokai/colors.lua
@@ -1,13 +1,13 @@
-local options = require("one_monokai.config").options
+local config = require "one_monokai.config"
 local legacy = require "one_monokai.legacy"
 
-local colors = {
+local default_colors = {
     -- main colors
     fg = "#abb2bf",
-    bg = "#282C34",
+    bg = "#282c34",
     warm_gray = "#676e7b",
     pink = "#e06c75",
-    green = "#98C379",
+    green = "#98c379",
     cyan = "#56b6c2",
     aqua = "#61afef",
     yellow = "#e5c07b",
@@ -20,7 +20,7 @@ local colors = {
     -- support colors
     light_black = "#2d2e27",
     vulcan = "#383a3e",
-    dark_black = "#26292F",
+    dark_black = "#26292f",
     darker_black = "#1e2024",
     gray = "#4b5261",
     light_gray = "#9ca3b2",
@@ -36,18 +36,18 @@ local colors = {
     },
 }
 
-local function set_colors(user_colors)
-    for name, color in pairs(user_colors) do
-        if type(color) == "table" then
-            return set_colors(color)
+local function set_color(colors)
+    for name, value in pairs(colors) do
+        if type(value) == "table" then
+            return set_color(value)
         else
-            if not legacy.check_color(name, color) then
-                return colors
+            if not legacy.check_colors(name, value) then
+                return default_colors
             end
         end
     end
 
-    return vim.tbl_deep_extend("force", colors, user_colors)
+    return vim.tbl_deep_extend("force", default_colors, colors)
 end
 
-return set_colors(options.colors)
+return set_color(config.options.colors)

--- a/lua/one_monokai/config.lua
+++ b/lua/one_monokai/config.lua
@@ -1,10 +1,9 @@
-local legacy = require "one_monokai.legacy"
-
 local M = {}
 
 M.options = {
     transparent = false,
     colors = {},
+
     ---@diagnostic disable-next-line: unused-local
     themes = function(colors)
         return {}
@@ -14,18 +13,6 @@ M.options = {
 M.extend = function(user_config)
     if user_config then
         M.options = vim.tbl_deep_extend("force", M.options, user_config)
-    end
-end
-
-M.load_theme = function()
-    local themes = require "one_monokai.themes"
-
-    for group, attrs in pairs(themes) do
-        local ok, err = pcall(vim.api.nvim_set_hl, 0, group, attrs)
-
-        if not ok then
-            legacy.log(err)
-        end
     end
 end
 

--- a/lua/one_monokai/init.lua
+++ b/lua/one_monokai/init.lua
@@ -2,9 +2,12 @@ local M = {}
 
 local set = vim.cmd
 local config = require "one_monokai.config"
+local themes = require "one_monokai.themes"
 
 M.setup = function(user_config)
-    set [[hi clear]]
+    if vim.g.colors_name then
+        set [[hi clear]]
+    end
 
     if vim.fn.exists "syntax_on" then
         set [[syntax reset]]
@@ -16,7 +19,7 @@ M.setup = function(user_config)
 
     -- load user config and themes
     config.extend(user_config)
-    config.load_theme()
+    themes.load()
 
     set [[colorscheme one_monokai]]
 end

--- a/lua/one_monokai/legacy/init.lua
+++ b/lua/one_monokai/legacy/init.lua
@@ -2,17 +2,19 @@ local M = {}
 
 M.log = function(message)
     vim.schedule(function()
-        vim.notify_once(message, vim.log.levels.ERROR, { title = "One Monokai" })
+        vim.notify_once(message, vim.log.levels.ERROR, {
+            title = "One Monokai",
+        })
     end)
 end
 
-M.check_color = function(name, color)
-    if color:lower() == "none" then
+M.check_colors = function(name, value)
+    if value:lower() == "none" then
         return true
     end
 
-    if vim.api.nvim_get_color_by_name(color) == -1 then
-        M.log(string.format("{ %s = %q } is not a valid color value", name, color))
+    if vim.api.nvim_get_color_by_name(value) == -1 then
+        M.log(string.format("colors(%s): %q is not a valid color", name, value))
 
         return false
     end

--- a/lua/one_monokai/themes.lua
+++ b/lua/one_monokai/themes.lua
@@ -1,287 +1,321 @@
-local options = require("one_monokai.config").options
-local colors = require "one_monokai.colors"
-local transparent = options.transparent
+local legacy = require "one_monokai.legacy"
+local config = require "one_monokai.config"
 
-local themes = {
-    Constant = { fg = colors.aqua },
-    Number = { fg = colors.purple },
-    Float = { fg = colors.purple },
-    Boolean = { fg = colors.aqua },
-    Character = { fg = colors.yellow },
-    String = { fg = colors.yellow },
+local M = {}
 
-    Type = { fg = colors.cyan },
-    Structure = { fg = colors.cyan },
-    StorageClass = { fg = colors.cyan },
-    Typedef = { fg = colors.cyan },
+local function default_themes(colors)
+    return {
+        Constant = { fg = colors.aqua },
+        Number = { fg = colors.purple },
+        Float = { fg = colors.purple },
+        Boolean = { fg = colors.aqua },
+        Character = { fg = colors.yellow },
+        String = { fg = colors.yellow },
 
-    Identifier = { fg = colors.green },
-    Function = { fg = colors.green },
+        Type = { fg = colors.cyan },
+        Structure = { fg = colors.cyan },
+        StorageClass = { fg = colors.cyan },
+        Typedef = { fg = colors.cyan },
 
-    Statement = { fg = colors.pink },
-    Operator = { fg = colors.pink },
-    Label = { fg = colors.pink },
-    Keyword = { fg = colors.cyan },
+        Identifier = { fg = colors.green },
+        Function = { fg = colors.green },
 
-    PreProc = { fg = colors.green },
-    Include = { fg = colors.pink },
-    Define = { fg = colors.pink },
-    Macro = { fg = colors.green },
-    PreCondit = { fg = colors.green },
+        Statement = { fg = colors.pink },
+        Operator = { fg = colors.pink },
+        Label = { fg = colors.pink },
+        Keyword = { fg = colors.cyan },
 
-    Special = { fg = colors.purple },
-    SpecialChar = { fg = colors.pink },
-    Delimiter = { fg = colors.pink },
-    SpecialComment = { fg = colors.cyan },
-    Tag = { fg = colors.pink },
+        PreProc = { fg = colors.green },
+        Include = { fg = colors.pink },
+        Define = { fg = colors.pink },
+        Macro = { fg = colors.green },
+        PreCondit = { fg = colors.green },
 
-    Todo = { fg = colors.orange, bold = true, italic = true },
-    Comment = { fg = colors.warm_gray, italic = true },
+        Special = { fg = colors.purple },
+        SpecialChar = { fg = colors.pink },
+        Delimiter = { fg = colors.pink },
+        SpecialComment = { fg = colors.cyan },
+        Tag = { fg = colors.pink },
 
-    Underlined = { fg = colors.green, underline = true },
-    Ignore = {},
-    Error = { fg = colors.error.fg, bg = colors.error.bg },
+        Todo = { fg = colors.orange, bold = true, italic = true },
+        Comment = { fg = colors.warm_gray, italic = true },
 
-    Normal = { fg = colors.fg, bg = transparent and colors.none or colors.bg },
-    SignColumn = { bg = transparent and colors.none or colors.bg },
-    LineNr = { fg = colors.gray },
-    CursorLineNr = { fg = colors.fg },
-    ColorColumn = { bg = colors.dark_black },
-    Cursor = { fg = colors.bg, bg = colors.fg },
-    CursorColumn = { bg = colors.vulcan },
-    CursorLine = { bg = colors.vulcan },
-    Nontext = { fg = colors.gray },
-    StatusLine = { fg = colors.light_gray, bg = colors.darker_black },
-    StatusLineNC = { fg = colors.light_gray, bg = colors.dark_black },
-    Tabline = { fg = colors.fg, bg = colors.dark_black, reverse = true },
-    Visual = { bg = colors.gray },
-    Search = { fg = colors.bg, bg = colors.yellow },
-    MatchParen = { fg = colors.fg, bold = true, underline = true },
-    Question = { fg = colors.yellow },
-    ModeMsg = { fg = colors.yellow },
-    MoreMsg = { fg = colors.yellow },
-    ErrorMsg = { fg = colors.bg, bg = colors.error.fg, standout = true },
-    WarningMsg = { fg = colors.yellow },
-    VertSplit = { fg = colors.darker_black, bg = colors.bg },
+        Underlined = { fg = colors.green, underline = true },
+        Ignore = { fg = colors.yellow },
+        Error = { fg = colors.error.fg, bg = colors.error.bg },
 
-    SpecialKey = { fg = colors.pink },
-    Title = { fg = colors.yellow },
-    Directory = { fg = colors.aqua },
+        Normal = { fg = colors.fg, bg = config.options.transparent and colors.none or colors.bg },
+        FloatTitle = { fg = colors.pink },
+        SignColumn = {},
+        LineNr = { fg = colors.gray },
+        CursorLineNr = { fg = colors.fg },
+        ColorColumn = { bg = colors.dark_black },
+        Cursor = { fg = colors.bg, bg = colors.fg },
+        CursorColumn = { bg = colors.vulcan },
+        CursorLine = { bg = colors.vulcan },
+        Nontext = { fg = colors.gray },
+        TermCursor = { fg = colors.pink },
+        StatusLine = { fg = colors.light_gray, bg = colors.darker_black },
+        StatusLineNC = { fg = colors.light_gray, bg = colors.dark_black },
+        Tabline = { fg = colors.fg, bg = colors.dark_black, reverse = true },
+        Visual = { bg = colors.gray },
+        Search = { fg = colors.bg, bg = colors.yellow },
+        MatchParen = { fg = colors.fg, bold = true, underline = true },
+        Question = { fg = colors.yellow },
+        ModeMsg = { fg = colors.yellow },
+        MoreMsg = { fg = colors.yellow },
+        ErrorMsg = { fg = colors.bg, bg = colors.error.fg, standout = true },
+        WarningMsg = { fg = colors.yellow },
+        VertSplit = { fg = colors.fg },
 
-    -- diff
-    DiffAdd = { fg = colors.git.add },
-    DiffDelete = { fg = colors.git.del },
-    DiffChange = { fg = colors.git.change },
-    DiffText = { fg = colors.bg, bg = colors.cyan },
+        SpecialKey = { fg = colors.pink },
+        Title = { fg = colors.yellow },
+        Directory = { fg = colors.aqua },
 
-    -- fold
-    Folded = { fg = colors.warm_gray, bg = colors.dark_black },
-    FoldColumn = { bg = colors.dark_black },
+        -- diff
+        DiffAdd = { fg = colors.git.add },
+        DiffDelete = { fg = colors.git.del },
+        DiffChange = { fg = colors.git.change },
+        DiffText = { fg = colors.bg, bg = colors.cyan },
 
-    -- popup menu
-    Pmenu = { fg = colors.fg, bg = colors.dark_black },
-    PmenuSel = { fg = colors.bg, bg = colors.pink },
-    PmenuThumb = { fg = colors.light_black, bg = colors.gray },
+        -- fold
+        Folded = { fg = colors.warm_gray, bg = colors.dark_black },
+        FoldColumn = { bg = colors.dark_black },
 
-    -- lsp document highlight
-    LspReferenceRead = { bg = colors.vulcan, bold = true },
-    LspReferenceText = { bg = colors.vulcan, bold = true },
-    LspReferenceWrite = { bg = colors.vulcan, bold = true },
+        -- popup menu
+        Pmenu = { fg = colors.fg },
+        PmenuSel = { fg = colors.bg, bg = colors.pink },
+        PmenuThumb = { fg = colors.light_black, bg = colors.gray },
 
-    -- dashboard
-    DashboardHeader = { fg = colors.peanut },
-    DashboardCenter = { fg = colors.roman },
-    DashboardFooter = { fg = colors.aqua },
+        -- lsp document highlight
+        LspReferenceRead = { bg = colors.vulcan, bold = true },
+        LspReferenceText = { bg = colors.vulcan, bold = true },
+        LspReferenceWrite = { bg = colors.vulcan, bold = true },
 
-    -- nvim tree
-    NvimTreeFolderIcon = { fg = colors.yellow },
-    NvimTreeGitStaged = { fg = colors.green },
-    NvimTreeGitDirty = { fg = colors.pink },
+        -- dashboard
+        DashboardHeader = { fg = colors.peanut },
+        DashboardCenter = { fg = colors.roman },
+        DashboardFooter = { fg = colors.aqua },
 
-    -- nvim-cmp
-    CmpItemAbbrMatch = { fg = colors.aqua },
-    CmpItemKindStruct = { fg = colors.pink },
-    CmpItemKindEnum = { fg = colors.pink },
-    CmpItemKindClass = { fg = colors.pink },
-    CmpItemKindInterface = { fg = colors.pink },
-    CmpItemKindValue = { fg = colors.git.change },
-    CmpItemKindKeyword = { fg = colors.git.change },
-    CmpItemKindText = { fg = colors.git.change },
-    CmpItemKindProperty = { fg = colors.yellow },
-    CmpItemKindMethod = { fg = colors.yellow },
-    CmpItemKindField = { fg = colors.yellow },
-    CmpItemKindModule = { fg = colors.yellow },
-    CmpItemKindEnumMember = { fg = colors.yellow },
-    CmpItemKindVariable = { fg = colors.cyan },
-    CmpItemKindConstant = { fg = colors.cyan },
-    CmpItemKindFunction = { fg = colors.green },
-    CmpItemAbbrDeprecated = { fg = colors.light_gray, strikethrough = true },
+        -- nvim tree
+        NvimTreeFolderIcon = { fg = colors.yellow },
+        NvimTreeGitStaged = { fg = colors.green },
+        NvimTreeGitDirty = { fg = colors.pink },
 
-    -- indent blankline
-    IndentBlanklineIndent1 = { fg = colors.pink, nocombine = true },
-    IndentBlanklineIndent2 = { fg = colors.yellow, nocombine = true },
-    IndentBlanklineIndent3 = { fg = colors.green, nocombine = true },
-    IndentBlanklineIndent4 = { fg = colors.cyan, nocombine = true },
-    IndentBlanklineIndent5 = { fg = colors.aqua, nocombine = true },
-    IndentBlanklineIndent6 = { fg = colors.purple, nocombine = true },
+        -- whichkey
+        WhichKeySeparator = { fg = colors.pink },
 
-    -- crate
-    CratesNvimNoMatch = { fg = colors.pink },
-    CratesNvimError = { fg = colors.git.del },
-    CratesNvimUpgrade = { fg = colors.yellow },
-    CratesNvimVersion = { fg = colors.green },
-    CratesNvimPreRelease = { fg = colors.cyan },
-    CratesNvimYanked = { fg = colors.git.del },
-    CratesNvimLoading = { fg = colors.purple },
-    CratesNvimPopupTitle = { fg = colors.purple },
-    CratesNvimPopupVersion = { fg = colors.green },
-    CratesNvimPopupPreRelease = { fg = colors.cyan },
-    CratesNvimPopupYanked = { fg = colors.pink },
-    CratesNvimPopupFeature = { fg = colors.aqua },
-    CratesNvimPopupEnabled = { fg = colors.green },
-    CratesNvimPopupTransitive = { fg = colors.pink },
+        -- nvim-cmp
+        CmpItemAbbrMatch = { fg = colors.aqua },
+        CmpItemKindStruct = { fg = colors.pink },
+        CmpItemKindEnum = { fg = colors.pink },
+        CmpItemKindClass = { fg = colors.pink },
+        CmpItemKindInterface = { fg = colors.pink },
+        CmpItemKindValue = { fg = colors.git.change },
+        CmpItemKindKeyword = { fg = colors.git.change },
+        CmpItemKindText = { fg = colors.git.change },
+        CmpItemKindProperty = { fg = colors.yellow },
+        CmpItemKindMethod = { fg = colors.yellow },
+        CmpItemKindField = { fg = colors.yellow },
+        CmpItemKindModule = { fg = colors.yellow },
+        CmpItemKindEnumMember = { fg = colors.yellow },
+        CmpItemKindVariable = { fg = colors.cyan },
+        CmpItemKindConstant = { fg = colors.cyan },
+        CmpItemKindFunction = { fg = colors.green },
+        CmpItemAbbrDeprecated = { fg = colors.light_gray, strikethrough = true },
 
-    -- notify
-    NotifyERRORBorder = { fg = colors.roman },
-    NotifyWARNBorder = { fg = colors.orange },
-    NotifyINFOBorder = { fg = colors.green },
-    NotifyDEBUGBorder = { fg = colors.purple },
-    NotifyTRACEBorder = { fg = colors.purple },
-    NotifyERRORIcon = { fg = colors.roman },
-    NotifyWARNIcon = { fg = colors.orange },
-    NotifyINFOIcon = { fg = colors.green },
-    NotifyDEBUGIcon = { fg = colors.purple },
-    NotifyTRACEIcon = { fg = colors.purple },
-    NotifyERRORTitle = { fg = colors.roman },
-    NotifyWARNTitle = { fg = colors.orange },
-    NotifyINFOTitle = { fg = colors.green },
-    NotifyDEBUGTitle = { fg = colors.purple },
-    NotifyTRACETitle = { fg = colors.purple },
-    NotifyERRORBody = { fg = colors.fg },
-    NotifyWARNBody = { fg = colors.fg },
-    NotifyINFOBody = { fg = colors.fg },
-    NotifyDEBUGBody = { fg = colors.fg },
-    NotifyTRACEBody = { fg = colors.fg },
+        -- indent blankline
+        IndentBlanklineIndent1 = { fg = colors.pink, nocombine = true },
+        IndentBlanklineIndent2 = { fg = colors.yellow, nocombine = true },
+        IndentBlanklineIndent3 = { fg = colors.green, nocombine = true },
+        IndentBlanklineIndent4 = { fg = colors.cyan, nocombine = true },
+        IndentBlanklineIndent5 = { fg = colors.aqua, nocombine = true },
+        IndentBlanklineIndent6 = { fg = colors.purple, nocombine = true },
 
-    -- java
-    jpropertiesIdentifier = { fg = colors.pink },
+        -- crate
+        CratesNvimNoMatch = { fg = colors.pink },
+        CratesNvimError = { fg = colors.git.del },
+        CratesNvimUpgrade = { fg = colors.yellow },
+        CratesNvimVersion = { fg = colors.green },
+        CratesNvimPreRelease = { fg = colors.cyan },
+        CratesNvimYanked = { fg = colors.git.del },
+        CratesNvimLoading = { fg = colors.purple },
+        CratesNvimPopupTitle = { fg = colors.purple },
+        CratesNvimPopupVersion = { fg = colors.green },
+        CratesNvimPopupPreRelease = { fg = colors.cyan },
+        CratesNvimPopupYanked = { fg = colors.pink },
+        CratesNvimPopupFeature = { fg = colors.aqua },
+        CratesNvimPopupEnabled = { fg = colors.green },
+        CratesNvimPopupTransitive = { fg = colors.pink },
 
-    -- vim
-    vimCommand = { fg = colors.pink },
+        -- notify
+        NotifyERRORBorder = { fg = colors.roman },
+        NotifyWARNBorder = { fg = colors.orange },
+        NotifyINFOBorder = { fg = colors.green },
+        NotifyDEBUGBorder = { fg = colors.purple },
+        NotifyTRACEBorder = { fg = colors.purple },
+        NotifyERRORIcon = { fg = colors.roman },
+        NotifyWARNIcon = { fg = colors.orange },
+        NotifyINFOIcon = { fg = colors.green },
+        NotifyDEBUGIcon = { fg = colors.purple },
+        NotifyTRACEIcon = { fg = colors.purple },
+        NotifyERRORTitle = { fg = colors.roman },
+        NotifyWARNTitle = { fg = colors.orange },
+        NotifyINFOTitle = { fg = colors.green },
+        NotifyDEBUGTitle = { fg = colors.purple },
+        NotifyTRACETitle = { fg = colors.purple },
+        NotifyERRORBody = { fg = colors.fg },
+        NotifyWARNBody = { fg = colors.fg },
+        NotifyINFOBody = { fg = colors.fg },
+        NotifyDEBUGBody = { fg = colors.fg },
+        NotifyTRACEBody = { fg = colors.fg },
 
-    jsFuncName = { fg = colors.green },
-    jsThis = { fg = colors.pink },
-    jsFunctionKey = { fg = colors.green },
-    jsPrototype = { fg = colors.cyan },
-    jsExceptions = { fg = colors.cyan },
-    jsFutureKeys = { fg = colors.cyan },
-    jsBuiltins = { fg = colors.cyan },
-    jsArgsObj = { fg = colors.cyan },
-    jsStatic = { fg = colors.cyan },
-    jsSuper = { fg = colors.cyan },
-    jsFuncArgRest = { fg = colors.purple, italic = true },
-    jsFuncArgs = { fg = colors.orange, italic = true },
-    jsStorageClass = { fg = colors.cyan },
-    jsDocTags = { fg = colors.cyan, italic = true },
-    javascriptTSConstructor = { fg = colors.aqua },
-    javascriptTSKeyWordReturn = { fg = colors.pink },
-    javascriptTSType = { fg = colors.aqua },
-    javascriptTSVariableBuiltin = { fg = colors.aqua },
-    javascriptTSParameter = { fg = colors.orange, italic = true },
+        -- java
+        jpropertiesIdentifier = { fg = colors.pink },
 
-    -- typescript
-    typescriptArrowFuncArg = { fg = colors.orange, italic = true },
-    typescriptFuncType = { fg = colors.orange, italic = true },
-    typescriptCall = { fg = colors.orange, italic = true },
-    typescriptVariable = { fg = colors.cyan },
-    typescriptVariableDeclaration = { fg = colors.aqua },
-    typescriptDOMEventProp = { fg = colors.aqua },
-    typescriptGlobal = { fg = colors.aqua },
-    typescriptModule = { fg = colors.cyan },
-    typescriptPredefinedType = { fg = colors.cyan },
-    typescriptFuncTypeArrow = { fg = colors.cyan },
-    typescriptImport = { fg = colors.pink },
-    typescriptExport = { fg = colors.pink },
-    typescriptCastKeyword = { fg = colors.pink },
-    typescriptOperator = { fg = colors.pink },
-    typescriptEndColons = { fg = colors.fg },
-    typescriptObjectLabel = { fg = colors.green },
-    typescriptAmbientDeclaration = { fg = colors.pink },
-    typescriptProp = { fg = colors.green },
-    typescriptAsyncFuncKeyword = { fg = colors.pink },
-    typescriptGlobalMethod = { fg = colors.green },
-    typescriptTypeReference = { fg = colors.aqua },
-    typescriptBinaryOp = { fg = colors.pink },
-    typescriptPromiseMethod = { fg = colors.green },
-    typescriptNull = { fg = colors.cyan },
-    typescriptArrayMethod = { fg = colors.green },
-    typescriptMember = { fg = colors.fg },
-    typescriptDestructureVariable = { fg = colors.aqua },
-    typescriptArrayStaticMethod = { fg = colors.green },
-    typescriptTSVariableBuiltin = { fg = colors.aqua },
-    typescriptTSNamespace = { fg = colors.aqua },
-    typescriptTSConstructor = { fg = colors.aqua },
-    typescriptTSParameter = { fg = colors.orange, italic = true },
-    typescriptTSKeywordReturn = { fg = colors.pink },
+        -- vim
+        vimCommand = { fg = colors.pink },
 
-    -- tsx
-    tsxAttrib = { fg = colors.green },
-    tsxTagName = { fg = colors.aqua },
-    tsxTSConstructor = { fg = colors.aqua },
-    tsxTSKeyWordReturn = { fg = colors.pink },
-    tsxTSType = { fg = colors.aqua },
-    tsxTSVariableBuiltin = { fg = colors.aqua },
-    tsxTSParameter = { fg = colors.orange, italic = true },
+        jsFuncName = { fg = colors.green },
+        jsThis = { fg = colors.pink },
+        jsFunctionKey = { fg = colors.green },
+        jsPrototype = { fg = colors.cyan },
+        jsExceptions = { fg = colors.cyan },
+        jsFutureKeys = { fg = colors.cyan },
+        jsBuiltins = { fg = colors.cyan },
+        jsArgsObj = { fg = colors.cyan },
+        jsStatic = { fg = colors.cyan },
+        jsSuper = { fg = colors.cyan },
+        jsFuncArgRest = { fg = colors.purple, italic = true },
+        jsFuncArgs = { fg = colors.orange, italic = true },
+        jsStorageClass = { fg = colors.cyan },
+        jsDocTags = { fg = colors.cyan, italic = true },
+        javascriptTSConstructor = { fg = colors.aqua },
+        javascriptTSKeyWordReturn = { fg = colors.pink },
+        javascriptTSType = { fg = colors.aqua },
+        javascriptTSVariableBuiltin = { fg = colors.aqua },
+        javascriptTSParameter = { fg = colors.orange, italic = true },
 
-    -- rust
-    rustIdentifier = { fg = colors.aqua },
-    rustKeyword = { fg = colors.pink },
-    rustType = { fg = colors.aqua },
-    rustSigil = { fg = colors.pink },
-    rustSelf = { fg = colors.pink },
-    rustLifetime = { fg = colors.pink },
-    rustLet = { fg = colors.cyan },
-    rustParamName = { fg = colors.orange, italic = true },
-    rustModPath = { fg = colors.aqua },
-    rustTSKeyword = { fg = colors.pink },
-    rustTSConstBuiltin = { fg = colors.aqua },
-    rustTSVariableBuiltin = { fg = colors.pink },
-    rustTSTypeBuiltin = { fg = colors.aqua },
-    rustTSType = { fg = colors.aqua },
-    rustTSParameter = { fg = colors.orange, italic = true },
-    rustTSKeywordFunction = { fg = colors.pink },
+        -- typescript
+        typescriptArrowFuncArg = { fg = colors.orange, italic = true },
+        typescriptFuncType = { fg = colors.orange, italic = true },
+        typescriptCall = { fg = colors.orange, italic = true },
+        typescriptVariable = { fg = colors.cyan },
+        typescriptVariableDeclaration = { fg = colors.aqua },
+        typescriptDOMEventProp = { fg = colors.aqua },
+        typescriptGlobal = { fg = colors.aqua },
+        typescriptModule = { fg = colors.cyan },
+        typescriptPredefinedType = { fg = colors.cyan },
+        typescriptFuncTypeArrow = { fg = colors.cyan },
+        typescriptImport = { fg = colors.pink },
+        typescriptExport = { fg = colors.pink },
+        typescriptCastKeyword = { fg = colors.pink },
+        typescriptOperator = { fg = colors.pink },
+        typescriptEndColons = { fg = colors.fg },
+        typescriptObjectLabel = { fg = colors.green },
+        typescriptAmbientDeclaration = { fg = colors.pink },
+        typescriptProp = { fg = colors.green },
+        typescriptAsyncFuncKeyword = { fg = colors.pink },
+        typescriptGlobalMethod = { fg = colors.green },
+        typescriptTypeReference = { fg = colors.aqua },
+        typescriptBinaryOp = { fg = colors.pink },
+        typescriptPromiseMethod = { fg = colors.green },
+        typescriptNull = { fg = colors.cyan },
+        typescriptArrayMethod = { fg = colors.green },
+        typescriptMember = { fg = colors.fg },
+        typescriptDestructureVariable = { fg = colors.aqua },
+        typescriptArrayStaticMethod = { fg = colors.green },
+        typescriptTSVariableBuiltin = { fg = colors.aqua },
+        typescriptTSNamespace = { fg = colors.aqua },
+        typescriptTSConstructor = { fg = colors.aqua },
+        typescriptTSParameter = { fg = colors.orange, italic = true },
+        typescriptTSKeywordReturn = { fg = colors.pink },
 
-    -- html
-    htmlTag = { fg = colors.fg },
-    htmlEndTag = { fg = colors.fg },
-    htmlTagName = { fg = colors.pink },
-    htmlArg = { fg = colors.green },
-    htmlSpecialChar = { fg = colors.purple },
+        -- tsx
+        tsxAttrib = { fg = colors.green },
+        tsxTagName = { fg = colors.aqua },
+        tsxTSConstructor = { fg = colors.aqua },
+        tsxTSKeyWordReturn = { fg = colors.pink },
+        tsxTSType = { fg = colors.aqua },
+        tsxTSVariableBuiltin = { fg = colors.aqua },
+        tsxTSParameter = { fg = colors.orange, italic = true },
 
-    -- xml
-    xmlTag = { fg = colors.pink },
-    xmlEndTag = { fg = colors.pink },
-    xmlTagName = { fg = colors.orange },
-    xmlAttrib = { fg = colors.green },
+        -- rust
+        rustIdentifier = { fg = colors.aqua },
+        rustKeyword = { fg = colors.pink },
+        rustType = { fg = colors.aqua },
+        rustSigil = { fg = colors.pink },
+        rustSelf = { fg = colors.pink },
+        rustLifetime = { fg = colors.pink },
+        rustLet = { fg = colors.cyan },
+        rustParamName = { fg = colors.orange, italic = true },
+        rustModPath = { fg = colors.aqua },
+        rustTSKeyword = { fg = colors.pink },
+        rustTSConstBuiltin = { fg = colors.aqua },
+        rustTSVariableBuiltin = { fg = colors.pink },
+        rustTSTypeBuiltin = { fg = colors.aqua },
+        rustTSType = { fg = colors.aqua },
+        rustTSParameter = { fg = colors.orange, italic = true },
+        rustTSKeywordFunction = { fg = colors.pink },
 
-    -- css
-    cssProp = { fg = colors.yellow },
-    cssUIAttr = { fg = colors.yellow },
-    cssFunctionName = { fg = colors.cyan },
-    cssColor = { fg = colors.purple },
-    cssPseudoClassId = { fg = colors.purple },
-    cssClassName = { fg = colors.green },
-    cssValueLength = { fg = colors.purple },
-    cssCommonAttr = { fg = colors.pink },
-    cssBraces = { fg = colors.fg },
-    cssClassNameDot = { fg = colors.pink },
-    cssURL = { fg = colors.orange, underline = true, italic = true },
+        -- html
+        htmlTag = { fg = colors.fg },
+        htmlEndTag = { fg = colors.fg },
+        htmlTagName = { fg = colors.pink },
+        htmlArg = { fg = colors.green },
+        htmlSpecialChar = { fg = colors.purple },
 
-    -- dockerfile
-    dockerfileTSKeyword = { fg = colors.pink },
+        -- xml
+        xmlTag = { fg = colors.pink },
+        xmlEndTag = { fg = colors.pink },
+        xmlTagName = { fg = colors.orange },
+        xmlAttrib = { fg = colors.green },
 
-    -- bash
-    bashTSParameter = { fg = colors.orange, italic = true },
-}
+        -- css
+        cssProp = { fg = colors.yellow },
+        cssUIAttr = { fg = colors.yellow },
+        cssFunctionName = { fg = colors.cyan },
+        cssColor = { fg = colors.purple },
+        cssPseudoClassId = { fg = colors.purple },
+        cssClassName = { fg = colors.green },
+        cssValueLength = { fg = colors.purple },
+        cssCommonAttr = { fg = colors.pink },
+        cssBraces = { fg = colors.fg },
+        cssClassNameDot = { fg = colors.pink },
+        cssURL = { fg = colors.orange, underline = true, italic = true },
 
-return vim.tbl_deep_extend("force", themes, options.themes(colors))
+        -- docker
+        dockerfileTSKeyword = { fg = colors.pink },
+
+        -- bash
+        bashTSParameter = { fg = colors.orange, italic = true },
+    }
+end
+
+local function set_theme(themes)
+    for group, attrs in pairs(themes) do
+        local status_ok, err = pcall(vim.api.nvim_set_hl, 0, group, attrs)
+
+        if not status_ok then
+            error(string.format("themes(%s): %s", group, err), 0)
+        end
+    end
+end
+
+M.load = function()
+    local colors = require "one_monokai.colors"
+    local default = default_themes(colors)
+    local user_themes = config.options.themes(colors)
+
+    user_themes = vim.tbl_deep_extend("force", default, user_themes)
+
+    local set_theme_ok, err = pcall(set_theme, user_themes)
+
+    if not set_theme_ok then
+        legacy.log(err)
+
+        set_theme(default)
+    end
+end
+
+return M


### PR DESCRIPTION
- Let `themes module` handle `load` function instead of `config module`. That make it easier to track theme's error config.
- Remove background highlight of `Pmenu` so that floating window now can be transparent.
- Change foreground highlight of `FloatTitle`.
- Remove all highlight of `SignColumn`. Its highlight will be set by default.