### PR TITLE
refactor(config)!: remove confusing option `use_cmd`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,7 @@ Or prefer below if you have your custom options
 
 ```lua
 require("one_monokai").setup({
-    use_cmd = true
-    --... other options
+    -- your options
 })
 ```
 
@@ -58,7 +57,6 @@ require("one_monokai").setup({
 
 | Option        | Description                            | Type       | Note                         |
 | ------------- | -------------------------------------- | ---------- | ---------------------------- |
-| `use_cmd`     | automatically set colorscheme on setup | `boolean`  | N/A                          |
 | `transparent` | enable transparent background          | `boolean`  | N/A                          |
 | `colors`      | custom colors                          | `table`    | N/A                          |
 | `themes`      | custom highlighting groups             | `function` | accepts `colors` as argument |
@@ -67,7 +65,6 @@ require("one_monokai").setup({
 
 ```lua
 {
-    use_cmd = false,
     transparent = false,
     colors = {},
     themes = function(colors)
@@ -85,7 +82,6 @@ You can easily change highlighting groups. Override the list of supported values
 
 ```lua
 require("one_monokai").setup({
-    use_cmd = true,
     colors = {
         green = "#00ff00",
         blue = "#0000ff",
@@ -143,8 +139,8 @@ Thanks for these talented and amazing people:
 
 - [one-monokai-vim](https://github.com/fratajczak/one-monokai-vim)
 - [vscode one-monokai](https://github.com/azemoh/vscode-one-monokai)
-- [tokyonight](https://github.com/folke/tokyonight.nvim)
-- [onedarkpro](https://github.com/olimorris/onedarkpro.nvim)
+- [tokyonight.nvim](https://github.com/folke/tokyonight.nvim)
+- [onedarkpro.nvim](https://github.com/olimorris/onedarkpro.nvim)
 
 ## :star: Cool One Monokai projects
 

--- a/lua/one_monokai/config.lua
+++ b/lua/one_monokai/config.lua
@@ -1,8 +1,6 @@
 local config = {}
 
 config.options = {
-    ---automatically set colorscheme on setup
-    use_cmd = false,
     ---enable transparent background
     transparent = false,
     ---@type table<string, string> #custom colors
@@ -24,6 +22,7 @@ function config:extend(user_config)
     self.options = vim.tbl_deep_extend("force", self.options, user_config)
 end
 
+-- allow index options without options field
 return setmetatable(config, {
     __index = function(table, key)
         return table.options[key]

--- a/lua/one_monokai/init.lua
+++ b/lua/one_monokai/init.lua
@@ -24,7 +24,7 @@ function M.setup(user_config)
     config:extend(user_config)
     themes.load()
 
-    if config.use_cmd then
+    if user_config then
         set.colorscheme "one_monokai"
     end
 end

--- a/tests/spec/config_spec.lua
+++ b/tests/spec/config_spec.lua
@@ -2,14 +2,12 @@ local config = require "one_monokai.config"
 
 describe("Config options", function()
     it("could be indexed without options field", function()
-        assert.are.same(false, config.use_cmd)
         assert.are.same({}, config.colors)
     end)
 end)
 
 describe("Override config", function()
     local expected = {
-        use_cmd = true,
         colors = {
             pink = "#61afef",
             lmao = "#dedeff",
@@ -26,7 +24,6 @@ describe("Override config", function()
     local colors = require "one_monokai.colors"
 
     it("should change the default config", function()
-        assert.are.same(true, config.use_cmd)
         assert.are.same(false, config.transparent)
         assert.are.same(expected.colors, config.colors)
         assert.are.same(expected.themes(colors), config.themes(colors))


### PR DESCRIPTION
The new `use_cmd` option is currently causing confusion about how to use it due to bad design in the first place. Remove it and use a better approach to decide whether we should set colorscheme on setup automatically when the user has defined their custom options.