### PR TITLE
chore: bump neovim version to 0.9.1

### DIFF
--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -25,7 +25,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # When the previous steps fails, the workflow would stop. By adding this
-      # condition you can continue the execution with the populated error message.
+      # condition we can continue the execution with the populated error message.
       - uses: marocchino/sticky-pull-request-comment@v2
         if: always() && (steps.lint_pr_title.outputs.error_message != null)
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,14 +13,14 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            neovim: 0.8.0
-            url: https://github.com/neovim/neovim/releases/download/v0.8.0/nvim-linux64.tar.gz
+            neovim: stable
+            url: https://github.com/neovim/neovim/releases/download/stable/nvim-linux64.tar.gz
           - os: ubuntu-latest
             neovim: nightly
             url: https://github.com/neovim/neovim/releases/download/nightly/nvim-linux64.tar.gz
           - os: macos-latest
-            neovim: 0.8.0
-            url: https://github.com/neovim/neovim/releases/download/v0.8.0/nvim-macos.tar.gz
+            neovim: stable
+            url: https://github.com/neovim/neovim/releases/download/stable/nvim-macos.tar.gz
           - os: macos-latest
             neovim: nightly
             url: https://github.com/neovim/neovim/releases/download/nightly/nvim-macos.tar.gz
@@ -43,7 +43,6 @@ jobs:
           git clone --depth 1 https://github.com/nvim-lua/plenary.nvim ~/.local/share/nvim/site/pack/vendor/start/plenary.nvim
           ln -s $PWD ~/.local/share/nvim/site/pack/vendor/start
       - name: Run tests
-        timeout-minutes: 4
         run: |
           export PATH="$PWD/_neovim/bin:$PATH"
           nvim --version

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ use "cpea2506/one_monokai.nvim"
 
 ### Requirement
 
-- Neovim >= 0.8.0
+- Neovim >= 0.9.1
 - [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter) for better syntax highlighting (optional) 😇
 
 ## :gear: Setup

--- a/tests/spec/config_spec.lua
+++ b/tests/spec/config_spec.lua
@@ -37,9 +37,9 @@ describe("Override config", function()
     end)
 
     it("should change default themes", function()
-        local hl = vim.api.nvim_get_hl_by_name("Normal", true)
+        local hl = vim.api.nvim_get_hl(0, { name = "Normal" })
 
-        assert.equal(expected.colors.lmao, ("#%06x"):format(hl.foreground))
+        assert.equal(expected.colors.lmao, ("#%06x"):format(hl.fg))
         assert.equal(true, hl.italic)
     end)
 


### PR DESCRIPTION
This will require user to update `neovim` to 0.9.1 for the best experience and stability.