### PR TITLE
fix(theme): use available default color

### DIFF
--- a/lua/one_monokai/themes/groups.lua
+++ b/lua/one_monokai/themes/groups.lua
@@ -360,7 +360,7 @@ groups.default = {
     CmpItemKindProperty = { fg = colors.yellow },
     CmpItemKindStruct = { fg = colors.pink },
     CmpItemKindText = { fg = colors.white },
-    CmpItemKindUnit = { fg = colors.light_orange },
+    CmpItemKindUnit = { fg = colors.orange },
     CmpItemKindValue = { fg = colors.white },
     CmpItemKindVariable = { fg = colors.cyan },
 


### PR DESCRIPTION
There is no `light_orange` color anymore. Use `orange` instead.