### PR TITLE
feat(themes): link `NormalFloat` to `Normal`

### DIFF
--- a/lua/one_monokai/themes/groups.lua
+++ b/lua/one_monokai/themes/groups.lua
@@ -59,6 +59,7 @@ local defaults = {
     MoreMsg = { fg = colors.yellow },
     Nontext = { fg = colors.dark_gray },
     Normal = { fg = colors.fg, bg = config.transparent and colors.none or colors.bg },
+    NormalFloat = { link = "Normal" },
     Question = { fg = colors.yellow },
     Search = { fg = colors.bg, bg = colors.yellow },
     SignColumn = {},


### PR DESCRIPTION
### Before:

<img width="1296" alt="Screenshot 2023-12-13 at 00 06 29" src="https://github.com/cpea2506/one_monokai.nvim/assets/42694704/6bbb810d-0077-4d80-96eb-0a1bd74a8ef8">

### After:

<img width="1296" alt="Screenshot 2023-12-13 at 00 06 58" src="https://github.com/cpea2506/one_monokai.nvim/assets/42694704/2e220c9f-37a6-453b-9d0b-8e35e5303530">
