### PR TITLE
Replace underline with undercurl for DiagnosticUnderline* groups

### DIFF
--- a/lua/one_monokai/themes/groups.lua
+++ b/lua/one_monokai/themes/groups.lua
@@ -252,10 +252,10 @@ local defaults = {
     DiagnosticError = { fg = colors.red },
     DiagnosticHint = { fg = colors.light_gray },
     DiagnosticInfo = { fg = colors.white },
-    DiagnosticUnderlineError = { sp = colors.red, underline = true },
-    DiagnosticUnderlineHint = { sp = colors.light_gray, underline = true },
-    DiagnosticUnderlineInfo = { sp = colors.green, underline = true },
-    DiagnosticUnderlineWarn = { sp = colors.yellow, underline = true },
+    DiagnosticUnderlineError = { sp = colors.red, undercurl = true },
+    DiagnosticUnderlineHint = { sp = colors.light_gray, undercurl = true },
+    DiagnosticUnderlineInfo = { sp = colors.green, undercurl = true },
+    DiagnosticUnderlineWarn = { sp = colors.yellow, undercurl = true },
     DiagnosticWarn = { fg = colors.yellow },
 
     -- lsp document highlight


### PR DESCRIPTION
This PR replaces `underline` with `undercurl` for the `DiagnosticUnderline*` groups. Neovim will fallback to underline in terminals that don't support it (see `:h :hi`).

Feel free to close this PR if you don't want the change.