### PR TITLE
feat(highlight): update `git-conflict` colors

### DIFF
--- a/lua/one_monokai/highlights/groups.lua
+++ b/lua/one_monokai/highlights/groups.lua
@@ -469,10 +469,10 @@ local defaults = {
     BlinkCmpKindVariable = { fg = colors.cyan },
 
     -- git-conflict
-    GitConflictCurrent = { bg = colors.cyan:darken(0.4) },
-    GitConflictIncoming = { bg = colors.green:darken(0.4) },
-    GitConflictCurrentLabel = { fg = colors.white },
-    GitConflictIncomingLabel = { fg = colors.white },
+    GitConflictCurrent = { bg = colors.cyan:darken(0.3) },
+    GitConflictIncoming = { bg = colors.aqua:darken(0.3) },
+    GitConflictCurrentLabel = { fg = colors.fg, bg = colors.cyan:darken(0.6) },
+    GitConflictIncomingLabel = { fg = colors.fg, bg = colors.aqua:darken(0.6) },
 
     -- lazy
     LazyButton = { fg = colors.white, bg = colors.vulcan },


### PR DESCRIPTION
<img width="1439" height="359" alt="Screenshot 2025-08-04 at 01 49 15" src="https://github.com/user-attachments/assets/a7487585-c714-43fd-87a7-4e15d155fa94" />
