### PR TITLE
fix: update cache when updating highlight groups and colors

### DIFF
--- a/lua/one_monokai/highlights/init.lua
+++ b/lua/one_monokai/highlights/init.lua
@@ -81,6 +81,11 @@ local function should_update_cache()
     end
 
     local hash = hashing(config.options)
+    local root = vim.fs.root(0, "lua")
+
+    if root then
+        hash = hash .. vim.fn.getftime(vim.fs.joinpath(root, ".git"))
+    end
 
     if hash ~= saved_hash then
         saved_hash_file = io.open(saved_hash_path, "wb")


### PR DESCRIPTION
Cache must be recompile when colors and highlight groups are updated from remote.